### PR TITLE
Use CURL rather than file_get_contents

### DIFF
--- a/src/Vendor.php
+++ b/src/Vendor.php
@@ -146,8 +146,23 @@ class Vendor
         }
 
         // Get the JSON conversion data.
-        if (!$json = file_get_contents(Vendor::URL_SUPPLY)) {
-            throw new VendorException("Could not load currency conversion JSON");
+        if (function_exists('curl_version')) {
+	    $ch = curl_init(Vendor::URL_SUPPLY);
+	    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+	    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+	    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+	    curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+	    $json = curl_exec($ch);
+	    curl_close($ch);
+        } else if (file_get_contents(__FILE__) && ini_get('allow_url_fopen')) {
+	        $json = file_get_contents(Vendor::URL_SUPPLY);
+        } else {
+	        throw new VendorException("Could not load currency conversion JSON");
+        }
+
+        // Check if the JSON data has been received.
+        if (empty($json)) {
+	        throw new VendorException("Could not load currency conversion JSON");
         }
 
         // Check the JSON is valid.


### PR DESCRIPTION
On some servers where allow_url_fopen is set to 0, the library will throw an error when file_get_contents() is called.

The changed code in this commit tries to use a CURL request instead to access the currency conversion data from https://supply.electroneum.com/app-value-v2.json, and uses file_get_contents as a backup if CURL is not installed.

Finally, it checks if the $json variable actually contains anything and throws an error if it was unsuccessful.